### PR TITLE
Fix issue #3 - Engine::new() waiting forever for input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ impl Engine {
             movetime: DEFAULT_TIME,
         };
 
-        res.read_line()?;
         res.command("uci")?;
 
         Ok(res)


### PR DESCRIPTION
The UCI specification allows an engine to not output anything before the `uci` command, and in this case reading a line won't ever succeed.

I removed the read_line() function call before sending the `uci` command to the engine.